### PR TITLE
Escape special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ cat test/leia.readme.js | grep "id: leia"
 cat test/leia.readme.js | grep retries | grep 6
 
 # Validate we set some envars
-cat test/leia.readme.js | grep "process.env.LEIA_PARSER_RUNNING = \'true\';"
+cat test/leia.readme.js | grep "process.env.LEIA_PARSER_RUNNING = 'true';"
 cat test/leia.readme.js | grep "process.env.LEIA_PARSER_VERSION"
 cat test/leia.readme.js | grep "process.env.LEIA_PARSER_ID"
 cat test/leia.readme.js | grep "process.env.LEIA_PARSER_RETRY"

--- a/examples/special-characters-example.md
+++ b/examples/special-characters-example.md
@@ -1,0 +1,30 @@
+Special Characters Example
+=============
+
+This is an example to test that special characters and quotes are properly escaped.
+And valid javascript strings are generated in the test.
+
+Testing
+-------
+
+Run some tests using stuff setup above.
+
+```bash
+# Should process special ('$pec!a1') characters.
+echo '"[]\/@%+=:,.-'
+
+# Should process quoted characters.
+echo "'\""
+
+# Should process special quoted characters.
+echo "\t\n'"
+
+# Should escape backslash character.
+echo lando psql -U postgres database -c "\dt"
+
+# Should process literal backslash characters.
+echo '\\literal\\'
+
+# Should  process quoted backslash.
+echo "\dt"
+```

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -23,6 +23,14 @@ const getTestType = (datum, {testHeader, setupHeader, cleanupHeader}) => {
 };
 
 /*
+ * Quote and escape a string to use in the template.
+ */
+const escapeString = text => {
+  // Escape single quotes and backslashes so they're now literal.
+  return '\'' + text.replace(/(['\\])/g, '\\$1') + '\'';
+};
+
+/*
  * Helper parse a test describe
  */
 const parseTestDescribe = describe => _.lowerCase(_.trim(_.trimStart(describe, '#')));
@@ -42,7 +50,7 @@ const parseTestCommand = test => {
     .value();
 
   // Concat and return
-  return lines.join(' && ');
+  return escapeString(lines.join(' && '));
 };
 
 /*

--- a/templates/exec.def
+++ b/templates/exec.def
@@ -1,7 +1,7 @@
   it('{{=test.describe[0]}}', done => {
     process.chdir(path.resolve(__dirname, '{{=it.run}}'));
     const cli = new CliTest();
-    cli.exec('{{=test.command}}').then(res => {
+    cli.exec({{=test.command}}).then(res => {
       if (res.error === null) {
         done();
       } else {

--- a/templates/spawn.def
+++ b/templates/spawn.def
@@ -1,7 +1,7 @@
   it('{{=test.describe[0]}}', done => {
     process.chdir(path.resolve(__dirname, '{{=it.run}}'));
     const cli = new CliTest();
-    cli.spawn('/bin/sh', ['-c', '{{=test.command}}'], {stdio: ['{{=it.stdin}}', 'pipe', 'pipe']}).then(res => {
+    cli.spawn('/bin/sh', ['-c', {{=test.command}}], {stdio: ['{{=it.stdin}}', 'pipe', 'pipe']}).then(res => {
       if (res.error === null) {
         done();
       } else {

--- a/test/leia.func.js
+++ b/test/leia.func.js
@@ -10,7 +10,7 @@
 
 // Set some helpful envvars so we know these are leia tezts
 process.env.LEIA_PARSER_RUNNING = 'true';
-process.env.LEIA_PARSER_VERSION = '0.3.4';
+process.env.LEIA_PARSER_VERSION = '0.4.0';
 process.env.LEIA_PARSER_ID = 'leia';
 process.env.LEIA_PARSER_RETRY = 3;
 

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -7,6 +7,8 @@
 
 const chai = require('chai');
 const path = require('path');
+const vm = require('vm');
+
 chai.should();
 
 const parse = require('./../lib/parse');
@@ -24,6 +26,27 @@ describe('parse', () => {
     const tests2 = parse([path.resolve(__dirname, '..', 'examples', 'basic-example.md')]);
     tests2[0].tests.should.not.have.all.keys('setup', 'cleanup');
     tests2[0].tests.should.have.all.keys('test', 'nope');
+  });
+  it('should escape special characters', () => {
+    const tests = parse([path.resolve(__dirname, '..', 'examples', 'special-characters-example.md')]);
+    tests[0].tests.test.should.be.an('Array').and.not.be.empty;
+    const evalRawString = rawString => {
+      rawString.should.be.a('String');
+      rawString.should.have.lengthOf.above(2);
+      // Starts and ends with single quotes.
+      rawString[0].should.equal(`'`);
+      rawString.charAt(rawString.length - 1).should.equal(`'`);
+      // Attempt to "safely" evaluate the raw string.
+      return vm.runInNewContext(rawString);
+    };
+    // Lodash's lowerCase should strip out special characters.
+    tests[0].tests.test[0].describe[0].should.equal('should process special pec a 1 characters');
+    evalRawString(tests[0].tests.test[0].command).should.equal(`echo '"[]\\/@%+=:,.-'`);
+    evalRawString(tests[0].tests.test[1].command).should.equal(`echo "'\\""`);
+    evalRawString(tests[0].tests.test[2].command).should.equal(`echo "\\t\\n'"`);
+    evalRawString(tests[0].tests.test[3].command).should.equal(`echo lando psql -U postgres database -c "\\dt"`);
+    evalRawString(tests[0].tests.test[4].command).should.equal(`echo '\\\\literal\\\\'`);
+    evalRawString(tests[0].tests.test[5].command).should.equal(`echo "\\dt"`);
   });
   it('should return tests as objects with description and command');
   it('should concatenate multiline test commands with a &');

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -7,7 +7,6 @@
 
 const chai = require('chai');
 const path = require('path');
-const vm = require('vm');
 
 chai.should();
 
@@ -30,23 +29,14 @@ describe('parse', () => {
   it('should escape special characters', () => {
     const tests = parse([path.resolve(__dirname, '..', 'examples', 'special-characters-example.md')]);
     tests[0].tests.test.should.be.an('Array').and.not.be.empty;
-    const evalRawString = rawString => {
-      rawString.should.be.a('String');
-      rawString.should.have.lengthOf.above(2);
-      // Starts and ends with single quotes.
-      rawString[0].should.equal(`'`);
-      rawString.charAt(rawString.length - 1).should.equal(`'`);
-      // Attempt to "safely" evaluate the raw string.
-      return vm.runInNewContext(rawString);
-    };
     // Lodash's lowerCase should strip out special characters.
     tests[0].tests.test[0].describe[0].should.equal('should process special pec a 1 characters');
-    evalRawString(tests[0].tests.test[0].command).should.equal(`echo '"[]\\/@%+=:,.-'`);
-    evalRawString(tests[0].tests.test[1].command).should.equal(`echo "'\\""`);
-    evalRawString(tests[0].tests.test[2].command).should.equal(`echo "\\t\\n'"`);
-    evalRawString(tests[0].tests.test[3].command).should.equal(`echo lando psql -U postgres database -c "\\dt"`);
-    evalRawString(tests[0].tests.test[4].command).should.equal(`echo '\\\\literal\\\\'`);
-    evalRawString(tests[0].tests.test[5].command).should.equal(`echo "\\dt"`);
+    tests[0].tests.test[0].command.should.equal(`'echo \\'"[]\\\\/@%+=:,.-\\''`);
+    tests[0].tests.test[1].command.should.equal(`'echo "\\'\\\\""'`);
+    tests[0].tests.test[2].command.should.equal(`'echo "\\\\t\\\\n\\'"'`);
+    tests[0].tests.test[3].command.should.equal(`'echo lando psql -U postgres database -c "\\\\dt"'`);
+    tests[0].tests.test[4].command.should.equal(`'echo \\'\\\\\\\\literal\\\\\\\\\\''`);
+    tests[0].tests.test[5].command.should.equal(`'echo "\\\\dt"'`);
   });
   it('should return tests as objects with description and command');
   it('should concatenate multiline test commands with a &');

--- a/test/setup-and-cleanup-example.func.js
+++ b/test/setup-and-cleanup-example.func.js
@@ -10,7 +10,7 @@
 
 // Set some helpful envvars so we know these are leia tezts
 process.env.LEIA_PARSER_RUNNING = 'true';
-process.env.LEIA_PARSER_VERSION = '0.3.4';
+process.env.LEIA_PARSER_VERSION = '0.4.0';
 process.env.LEIA_PARSER_ID = 'setup-and-cleanup-example';
 process.env.LEIA_PARSER_RETRY = 3;
 

--- a/test/special-characters-example.func.js
+++ b/test/special-characters-example.func.js
@@ -4,14 +4,14 @@
  * See https://github.com/lando/leia for more
  * information on how all this magic works
  *
- * id: basic-example
+ * id: special-characters-example
  * runs-from: ../examples
  */
 
 // Set some helpful envvars so we know these are leia tezts
 process.env.LEIA_PARSER_RUNNING = 'true';
 process.env.LEIA_PARSER_VERSION = '0.4.0';
-process.env.LEIA_PARSER_ID = 'basic-example';
+process.env.LEIA_PARSER_ID = 'special-characters-example';
 process.env.LEIA_PARSER_RETRY = 3;
 
 // We need these deps to run our tezts
@@ -22,16 +22,16 @@ chai.should();
 
 /* eslint-disable max-len */
 
-describe('basic-example', function() {
+describe('special-characters-example', function() {
   this.retries(3);
 
   // These tests are the main event
   // @todo: It would be nice to eventually get these into mocha after hooks
   // so they run after every test
-  it('should return true', done => {
+  it('should process special pec a 1 characters', done => {
     process.chdir(path.resolve(__dirname, '../examples'));
     const cli = new CliTest();
-    cli.spawn('/bin/sh', ['-c', 'true'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
+    cli.spawn('/bin/sh', ['-c', 'echo \'"[]\\/@%+=:,.-\''], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
       if (res.error === null) {
         done();
       } else {
@@ -41,10 +41,10 @@ describe('basic-example', function() {
     });
   });
 
-  it('should echo some stuff', done => {
+  it('should process quoted characters', done => {
     process.chdir(path.resolve(__dirname, '../examples'));
     const cli = new CliTest();
-    cli.spawn('/bin/sh', ['-c', 'echo "some stuff"'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
+    cli.spawn('/bin/sh', ['-c', 'echo "\'\\""'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
       if (res.error === null) {
         done();
       } else {
@@ -54,10 +54,10 @@ describe('basic-example', function() {
     });
   });
 
-  it('should return status code 1', done => {
+  it('should process special quoted characters', done => {
     process.chdir(path.resolve(__dirname, '../examples'));
     const cli = new CliTest();
-    cli.spawn('/bin/sh', ['-c', 'cat filedoesnotexist || echo $? | grep 1'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
+    cli.spawn('/bin/sh', ['-c', 'echo "\\t\\n\'"'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
       if (res.error === null) {
         done();
       } else {
@@ -67,10 +67,10 @@ describe('basic-example', function() {
     });
   });
 
-  it('should concatenate three commands together', done => {
+  it('should escape backslash character', done => {
     process.chdir(path.resolve(__dirname, '../examples'));
     const cli = new CliTest();
-    cli.spawn('/bin/sh', ['-c', 'export TEST=thing && env | grep TEST && unset TEST'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
+    cli.spawn('/bin/sh', ['-c', 'echo lando psql -U postgres database -c "\\dt"'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
       if (res.error === null) {
         done();
       } else {
@@ -80,10 +80,10 @@ describe('basic-example', function() {
     });
   });
 
-  it('should not concatenate if escape is used', done => {
+  it('should process literal backslash characters', done => {
     process.chdir(path.resolve(__dirname, '../examples'));
     const cli = new CliTest();
-    cli.spawn('/bin/sh', ['-c', 'export TEST=thing  TEST2=stuff  TEST3=morestuff && env | grep TEST && env | grep TEST2 && env | grep TEST3 && unset TEST && unset TEST2 && unset TEST3'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
+    cli.spawn('/bin/sh', ['-c', 'echo \'\\\\literal\\\\\''], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
       if (res.error === null) {
         done();
       } else {
@@ -93,23 +93,10 @@ describe('basic-example', function() {
     });
   });
 
-  it('should also run this', done => {
+  it('should process quoted backslash', done => {
     process.chdir(path.resolve(__dirname, '../examples'));
     const cli = new CliTest();
-    cli.spawn('/bin/sh', ['-c', 'true'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
-      if (res.error === null) {
-        done();
-      } else {
-        const error = [`CODE: ${res.error.code}`, `STDOUT: ${res.stdout}`, `STDERR: ${res.stderr}`].join('\n');
-        done(new Error(error));
-      }
-    });
-  });
-
-  it('should also also run this', done => {
-    process.chdir(path.resolve(__dirname, '../examples'));
-    const cli = new CliTest();
-    cli.spawn('/bin/sh', ['-c', 'true'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
+    cli.spawn('/bin/sh', ['-c', 'echo "\\dt"'], {stdio: ['pipe', 'pipe', 'pipe']}).then(res => {
       if (res.error === null) {
         done();
       } else {

--- a/test/stdin-example.func.js
+++ b/test/stdin-example.func.js
@@ -10,7 +10,7 @@
 
 // Set some helpful envvars so we know these are leia tezts
 process.env.LEIA_PARSER_RUNNING = 'true';
-process.env.LEIA_PARSER_VERSION = '0.3.4';
+process.env.LEIA_PARSER_VERSION = '0.4.0';
 process.env.LEIA_PARSER_ID = 'stdin-example';
 process.env.LEIA_PARSER_RETRY = 3;
 

--- a/test/subdirectory-example.func.js
+++ b/test/subdirectory-example.func.js
@@ -10,7 +10,7 @@
 
 // Set some helpful envvars so we know these are leia tezts
 process.env.LEIA_PARSER_RUNNING = 'true';
-process.env.LEIA_PARSER_VERSION = '0.3.4';
+process.env.LEIA_PARSER_VERSION = '0.4.0';
 process.env.LEIA_PARSER_ID = 'subdirectory-example';
 process.env.LEIA_PARSER_RETRY = 3;
 


### PR DESCRIPTION
Addresses #11

It now automatically escapes single quotes and backslashes in the commands.

-----

- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/leia/tree/master/CHANGELOG.md)
- [x] My code includes documentation updates if applicable.
- [x] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
