### PR TITLE
docs: prepare Leia release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,26 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-- Added `--module-format` for auto or explicit CommonJS and ESM harness generation. [#59](https://github.com/lando/leia/issues/59)
-- Added `runAsync()` for CommonJS/ESM loading while preserving synchronous `run()` for CommonJS. [#59](https://github.com/lando/leia/issues/59)
-- Fixed automatic shell selection to honor Unix account shells and use explicit platform fallback precedence. [#75](https://github.com/lando/leia/issues/75)
-- Fixed generated Mocha harness failures caused by valid shell syntax in executable Markdown. [#57](https://github.com/lando/leia/issues/57)
-- Fixed generated harness validation and serialization for numeric options, paths, shell values, and identifiers. [#73](https://github.com/lando/leia/issues/73)
-- Fixed test numbering across repeated setup, test, and cleanup sections. [#75](https://github.com/lando/leia/issues/75)
-- Raised the supported Node.js engine floor from 18 to 24 and standardized development and automation on Node 24 LTS [#60](https://github.com/lando/leia/issues/60)
+### New Features
+
+- Added `--module-format` for auto or explicit CommonJS and ESM harness generation. [#59](https://github.com/lando/leia/issues/59) [#72](https://github.com/lando/leia/pull/72)
+- Added `runAsync()` for CommonJS/ESM loading while preserving synchronous `run()` for CommonJS. [#59](https://github.com/lando/leia/issues/59) [#72](https://github.com/lando/leia/pull/72)
+
+### Bug Fixes
+
+- Fixed automatic shell selection to honor Unix account shells and explicit platform fallback precedence. [#75](https://github.com/lando/leia/issues/75) [#76](https://github.com/lando/leia/pull/76)
+- Fixed generated harness validation and serialization for numeric options, paths, shell values, and identifiers. [#73](https://github.com/lando/leia/issues/73) [#78](https://github.com/lando/leia/pull/78)
+- Fixed generated Mocha harness failures caused by valid shell syntax in executable Markdown. [#57](https://github.com/lando/leia/issues/57) [#71](https://github.com/lando/leia/pull/71)
+- Fixed test numbering across repeated setup, test, and cleanup sections. [#75](https://github.com/lando/leia/issues/75) [#76](https://github.com/lando/leia/pull/76)
+
+### Compatibility
+
+- Raised the supported Node.js engine floor from 18 to 24 and standardized development and automation on Node 24 LTS. [#60](https://github.com/lando/leia/issues/60) [#70](https://github.com/lando/leia/pull/70)
+- Updated `mocha` from version 9 to 11. [#49](https://github.com/lando/leia/pull/49) [#50](https://github.com/lando/leia/pull/50)
+
+### Developer Notes
+
+- Updated npm prerelease promotion to move the `latest` tag when a prerelease becomes stable. [#53](https://github.com/lando/leia/pull/53)
+- Updated npm publishing to use OIDC trusted publishing and least-privilege workflow permissions. [#74](https://github.com/lando/leia/issues/74) [#79](https://github.com/lando/leia/pull/79)
 
 ## v1.0.0-beta.4 - [July 22, 2024](https://github.com/lando/leia/releases/tag/v1.0.0-beta.4)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,49 @@
-Contributing
-============
+# Contributing to Leia
 
-Contributing is easy
+Leia welcomes focused bug fixes, features, tests, and documentation improvements. Open an issue first when a change
+needs design discussion or when you are unsure whether it fits the project.
 
-1. Follow the [dev instructions](https://github.com/lando/leia#development) to get running
-2. Visit [Leia](https://github.com/lando/leia) on GitHub and [fork it](https://guides.github.com/activities/forking/)
-3. Do some work locally and when its ready to go [follow this](https://guides.github.com/introduction/flow/)
+## Local setup
 
+Leia requires Node.js 24 or newer. The root `.node-version` is the runtime authority.
+
+```bash
+git clone https://github.com/lando/leia.git
+cd leia
+npm install
+```
+
+If you prefer not to install Node.js locally, use
+[Lando](https://docs.lando.dev/basics/installation.html):
+
+```bash
+git clone https://github.com/lando/leia.git
+cd leia
+lando start
+```
+
+The Lando app exposes `node`, `npm`, and `npx` commands through its Node 24 service.
+
+## Validate changes
+
+Run the focused local checks before opening a pull request:
+
+```bash
+npm run lint
+npm run test:unit
+```
+
+With Lando, prefix those commands with `lando`, for example `lando npm run lint`.
+
+The full Leia, shell, module-format, and operating-system scenarios run in CI. Add or update the narrowest unit test or
+executable example that owns the behavior you changed.
+
+## Open a pull request
+
+- Keep the change focused and connect it to its issue when one exists.
+- Update the README and unreleased changelog when behavior changes for users or developers.
+- Describe what changed and include the validation you ran.
+- Make sure the automated checks pass before requesting review.
+
+For help, join the `#contributors` channel in the
+[Lando Slack community](https://www.launchpass.com/devwithlando).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Leia will
 
 ## Installation
 
+Leia 1.x requires Node.js 24 or newer.
+
 ```bash
 # With npm
 npm install @lando/leia
@@ -19,17 +21,19 @@ npm install @lando/leia
 
 ## Basics
 
-A _very_ basic example of a valid Leia test is below. It _must_ have a single H1 header, at least one H2 header and then a code block
-where the comment is the human readable test description and the command below is the test.
+A basic Leia test needs one H1 heading, at least one matching H2 test heading, and a fenced code block.
+Inside the code block, a comment describes the test and the following line runs its command.
 
-```md
+````md
 # Some Example
 
 ## Testing
 
-# A description of my test
-the command i am running
+```bash
+# Should print a greeting
+echo "Hello from Leia"
 ```
+````
 
 ## Usage
 
@@ -139,27 +143,28 @@ both formats and loads native ESM through Mocha's asynchronous loader.
 
 ## Markdown Syntax
 
-In order for your `markdown` file to be recognized as containing functional tests it needs to have at least the following
+For a Markdown file to be recognized as containing functional tests, it needs at least the following:
 
-#### 1. A h1 Header
+### 1. An H1 heading
 
 ```md
 # Something to identify these tests
 ```
 
-#### 2. A h2 Header
+### 2. An H2 test heading
 
-By default our parser will look for a section that beings with the word "Testing". This section will contain your tests.
+By default, Leia looks for sections beginning with "Testing". These sections contain your tests.
 
 ```md
 ## Testing
 ```
 
-You can customize the word(s) that `leia` will look for to identify the testing section(s) using the `--test-header` option. You can also run `npm leia --help` to get a list of default words.
+Customize the words Leia uses to identify test sections with `--test-header`. Run `npx leia --help` to see the defaults.
 
-#### 3. A code block with at least one command and comment
+### 3. A fenced code block with a comment and command
 
-Under the above h2 sections you need to have a triple tick [markdown code block](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#code) that contains at least one comment and one command. The comment will be the human readable description of what the test does.
+Under a matching H2 heading, add a fenced code block containing at least one comment and one command. The
+comment becomes the human-readable test description.
 
 Here is a basic code block that runs one test
 
@@ -168,14 +173,14 @@ Here is a basic code block that runs one test
 cat test.txt
 ```
 
-If you want to learn more about the syntax and how `leia` puts together the above, check out [this example](https://github.com/lando/leia/blob/main/examples/basic-example.md)
+For more syntax examples, see the [basic executable example](https://github.com/lando/leia/blob/main/examples/basic-example.md).
 
 ## Skipping
 
 You can also skip tests. This is useful if you want to stub out a test for later.
 
 ```bash
-# Should write this test later and dont want to forget it
+# Should write this test later and not forget it
 skip
 ```
 
@@ -230,39 +235,15 @@ If you'd like to report a bug or submit a feature request then please [use the i
 
 ## Changelog
 
-We try to log all changes big and small in both [THE CHANGELOG](https://github.com/lando/leia/blob/main/CHANGELOG.md) and the [release notes](https://github.com/lando/leia/releases).
+User- and developer-visible changes are recorded in the
+[changelog](https://github.com/lando/leia/blob/main/CHANGELOG.md) and published
+[release notes](https://github.com/lando/leia/releases).
 
 ## Development
 
-Leia development requires [Node 24 LTS](https://nodejs.org/dist/latest-v24.x/). The root `.node-version` is the runtime authority for version-aware local tooling and GitHub Actions.
-
-```bash
-git clone https://github.com/lando/leia.git && cd leia
-npm install
-```
-
-If you don't want to install Node 24 locally, you can install [Lando](https://docs.lando.dev/basics/installation.html) and use that:
-
-```bash
-git clone https://github.com/lando/leia.git && cd leia
-# Install deps and get node
-lando start
-
-# Run commands
-lando node
-lando npm install
-lando npx leia
-```
-
-## Testing
-
-```bash
-# Lint the code
-npm run lint
-
-# Run unit tests
-npm run test:unit
-```
+Leia development requires [Node 24 LTS](https://nodejs.org/dist/latest-v24.x/). The root `.node-version` is the runtime
+authority for version-aware local tooling and GitHub Actions. See [CONTRIBUTING.md](./CONTRIBUTING.md) for local setup,
+Lando-based setup, validation, and pull request guidance.
 
 ## Releasing
 


### PR DESCRIPTION
## Summary

- Correct the README's basic Markdown example and surface the Node.js 24 requirement at installation.
- Replace the legacy contributor stub with current npm, Lando, validation, and pull request guidance.
- Organize the unreleased changelog into release-friendly sections and reconcile it with the full `v1.0.0-beta.4..HEAD` range, including PR links.

## Optimizer result

The docs surface had action-worthy correctness and maintainability drift. The repository remains in full-README mode; a docs-site split is not justified for Leia's current scope.

## Validation

- `git diff --check`
- Exact unreleased heading check
- Case-insensitive alphabetical ordering check within each changelog subsection
- Changelog visible-text length check
- Signed commit verification

The full Leia and cross-platform scenario suites were not run locally because repository guidance treats them as CI-owned by default.

## Scope

This PR prepares documentation and the changelog only. It does not select a version, tag, publish, or otherwise perform the release.