### PR TITLE
ci: harden npm release workflow

### DIFF
--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,0 +1,74 @@
+name: Release tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  release-tests:
+    name: release-tests (${{ matrix.npm_tag }})
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - release_version: v9.9.9
+            npm_tag: latest
+          - release_version: v9.9.9-ci.${{ github.event.pull_request.head.sha }}
+            npm_tag: edge
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Install Node from .node-version
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: '.node-version'
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - name: Install dependencies
+        run: npm clean-install --prefer-offline
+      - name: Prepare synthetic release
+        uses: tanaabased/prepare-release-action@v1
+        with:
+          sync: false
+          version: ${{ matrix.release_version }}
+          update-files: CHANGELOG.md
+          update-files-header: |
+            ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
+          update-files-meta: |
+            UNRELEASED_DATE=January 1, 2099
+            UNRELEASED_LINK=https://github.com/${{ github.repository }}/releases/tag/${{ matrix.release_version }}
+            UNRELEASED_VERSION=${{ matrix.release_version }}
+      - name: Validate prepared release
+        shell: bash
+        env:
+          EXPECTED_TAG: ${{ matrix.npm_tag }}
+          EXPECTED_VERSION: ${{ matrix.release_version }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" != "${EXPECTED_VERSION#v}" ]]; then
+            echo "Expected package version ${EXPECTED_VERSION#v}, got $VERSION" >&2
+            exit 1
+          fi
+
+          if [[ "$VERSION" == *-* ]]; then
+            TAG=edge
+          else
+            TAG=latest
+          fi
+
+          if [[ "$TAG" != "$EXPECTED_TAG" ]]; then
+            echo "Expected npm tag $EXPECTED_TAG, resolved $TAG" >&2
+            exit 1
+          fi
+
+          grep --fixed-strings "## $EXPECTED_VERSION - [January 1, 2099]" CHANGELOG.md
+      - name: Upgrade npm for publish validation
+        run: npm install --global "npm@^11.5.1"
+      - name: Validate npm publish
+        env:
+          NPM_TAG: ${{ matrix.npm_tag }}
+        run: npm publish --access public --tag "$NPM_TAG" --dry-run

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -27,48 +27,14 @@ jobs:
         with:
           node-version-file: '.node-version'
           registry-url: https://registry.npmjs.org
-          cache: npm
-      - name: Install dependencies
-        run: npm clean-install --prefer-offline
       - name: Prepare synthetic release
         uses: tanaabased/prepare-release-action@v1
         with:
           sync: false
           version: ${{ matrix.release_version }}
-          update-files: CHANGELOG.md
-          update-files-header: |
-            ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
-          update-files-meta: |
-            UNRELEASED_DATE=January 1, 2099
-            UNRELEASED_LINK=https://github.com/${{ github.repository }}/releases/tag/${{ matrix.release_version }}
-            UNRELEASED_VERSION=${{ matrix.release_version }}
-      - name: Validate prepared release
-        shell: bash
-        env:
-          EXPECTED_TAG: ${{ matrix.npm_tag }}
-          EXPECTED_VERSION: ${{ matrix.release_version }}
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if [[ "$VERSION" != "${EXPECTED_VERSION#v}" ]]; then
-            echo "Expected package version ${EXPECTED_VERSION#v}, got $VERSION" >&2
-            exit 1
-          fi
-
-          if [[ "$VERSION" == *-* ]]; then
-            TAG=edge
-          else
-            TAG=latest
-          fi
-
-          if [[ "$TAG" != "$EXPECTED_TAG" ]]; then
-            echo "Expected npm tag $EXPECTED_TAG, resolved $TAG" >&2
-            exit 1
-          fi
-
-          grep --fixed-strings "## $EXPECTED_VERSION - [January 1, 2099]" CHANGELOG.md
-      - name: Upgrade npm for publish validation
-        run: npm install --global "npm@^11.5.1"
       - name: Validate npm publish
         env:
           NPM_TAG: ${{ matrix.npm_tag }}
-        run: npm publish --access public --tag "$NPM_TAG" --dry-run
+        run: |
+          npm install --global "npm@^11.5.1"
+          npm publish --access public --tag "$NPM_TAG" --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,56 +1,27 @@
-name: Publish to NPM
+name: Release
 
 on:
   release:
     types:
       - published
-      - released
-jobs:
-  # When a prerelease is promoted to a full release, update the npm latest tag
-  promote:
-    if: github.event.action == 'released'
-    permissions:
-      contents: read
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-      - name: Install Node from .node-version
-        uses: actions/setup-node@v7
-        with:
-          node-version-file: '.node-version'
-          registry-url: https://registry.npmjs.org
-      - name: Install supported npm CLI
-        run: |
-          npm install --global npm@11.5.1
-          npm --version
-      - name: Promote edge to latest
-        run: |
-          VERSION=$(echo "$TAG_NAME" | sed 's/^v//')
-          PACKAGE=$(node -p "require('./package.json').name")
-          npm dist-tag add "$PACKAGE@$VERSION" latest
-          echo "::notice title=Promoted $VERSION to latest::The latest tag now points to $VERSION (was edge-only)"
-        env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_DEPLOY_TOKEN }}
 
-  deploy:
-    if: github.event.action == 'published'
+permissions:
+  contents: read
+
+jobs:
+  release-npm:
+    name: Publish npm package
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
-    runs-on: ${{ matrix.os }}
     env:
       TERM: xterm
-      PRERELEASE_TAG: edge
-    strategy:
-      matrix:
-        os:
-          - ubuntu-24.04
     steps:
-      # Install deps and cache
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Install Node from .node-version
         uses: actions/setup-node@v7
         with:
@@ -58,23 +29,22 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
       - name: Install dependencies
-        run: npm clean-install --prefer-offline --frozen-lockfile
-
-      # Let's do tests rq just to make sure we dont push something that is fundamentally broken
-      - name: Lint code
-        run: npm run lint
-      - name: Run unit tests
-        run: npm run test:unit
-      - name: Run leia tests
-        run: npx leia examples/basic-example.md
+        run: npm clean-install --prefer-offline
+      - name: Validate source
+        run: |
+          npm run lint
+          npm run test:unit
+          npm run test:leia
       - name: Export formatted release date
-        run: echo "RELEASE_DATE=$(date -d "${{ github.event.release.published_at }}" "+%B %e, %Y" | tr -s ' ')" >> $GITHUB_ENV
+        shell: bash
+        env:
+          PUBLISHED_AT: ${{ github.event.release.published_at }}
+        run: echo "RELEASE_DATE=$(date -d "$PUBLISHED_AT" "+%B %e, %Y" | tr -s ' ')" >> "$GITHUB_ENV"
       - name: Prepare release
-        uses: lando/prepare-release-action@v3
+        uses: tanaabased/prepare-release-action@v1
         with:
-          sync-token: ${{ secrets.RTFM47_COAXIUM_INJECTOR }}
-          sync-email: rtfm47@lando.dev
-          sync-username: rtfm-47
+          sync: false
+          version: ${{ github.event.release.tag_name }}
           update-files: CHANGELOG.md
           update-files-header: |
             ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
@@ -82,18 +52,64 @@ jobs:
             UNRELEASED_DATE=${{ env.RELEASE_DATE }}
             UNRELEASED_LINK=${{ github.event.release.html_url }}
             UNRELEASED_VERSION=${{ github.event.release.tag_name }}
-      - name: Install supported npm CLI
+      - name: Resolve npm channel
+        id: npm_channel
+        shell: bash
+        env:
+          GITHUB_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
-          npm install --global npm@11.5.1
-          npm --version
-      - name: Publish to npm
-        run: |
-          if [ "${{ github.event.release.prerelease }}" ==  "false" ]; then
-            npm publish --access public --dry-run
-            npm publish --access public
-            echo "::notice title=Published ${{ github.ref_name }} to @${{ github.repository }}::This is a stable release published to the default 'latest' npm tag"
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            TAG=edge
+            EXPECTED_PRERELEASE=true
           else
-            npm publish --access public --tag ${{ env.PRERELEASE_TAG }} --dry-run
-            npm publish --access public --tag ${{ env.PRERELEASE_TAG }}
-            echo "::notice title=Published ${{ github.ref_name }} to @${{ github.repository }}@${{ env.PRERELEASE_TAG }}::This is a pre-release published to the '${{ env.PRERELEASE_TAG }}' npm tag"
+            TAG=latest
+            EXPECTED_PRERELEASE=false
           fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_PRERELEASE" != "$EXPECTED_PRERELEASE" ]]; then
+            echo "::warning title=Release metadata mismatch::Publishing $VERSION to '$TAG' based on its semver, ignoring GitHub prerelease=$GITHUB_PRERELEASE"
+          fi
+      - name: Upgrade npm for trusted publishing
+        run: npm install --global "npm@^11.5.1"
+      - name: Publish package with trusted publishing
+        env:
+          NPM_TAG: ${{ steps.npm_channel.outputs.tag }}
+        run: |
+          npm publish --access public --tag "$NPM_TAG" --dry-run
+          npm publish --access public --tag "$NPM_TAG"
+
+  finalize:
+    name: Finalize release
+    needs:
+      - release-npm
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Export formatted release date
+        shell: bash
+        env:
+          PUBLISHED_AT: ${{ github.event.release.published_at }}
+        run: echo "RELEASE_DATE=$(date -d "$PUBLISHED_AT" "+%B %e, %Y" | tr -s ' ')" >> "$GITHUB_ENV"
+      - name: Prepare and synchronize release
+        uses: tanaabased/prepare-release-action@v1
+        with:
+          sync: true
+          version: ${{ github.event.release.tag_name }}
+          sync-token: ${{ secrets.RTFM47_COAXIUM_INJECTOR }}
+          sync-email: rtfm47@lando.dev
+          sync-username: rtfm-47
+          sync-verified: true
+          update-files: CHANGELOG.md
+          update-files-header: |
+            ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
+          update-files-meta: |
+            UNRELEASED_DATE=${{ env.RELEASE_DATE }}
+            UNRELEASED_LINK=${{ github.event.release.html_url }}
+            UNRELEASED_VERSION=${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Publish npm package
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
       id-token: write
     env:
       TERM: xterm
@@ -43,63 +43,6 @@ jobs:
       - name: Prepare release
         uses: tanaabased/prepare-release-action@v1
         with:
-          sync: false
-          version: ${{ github.event.release.tag_name }}
-          update-files: CHANGELOG.md
-          update-files-header: |
-            ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
-          update-files-meta: |
-            UNRELEASED_DATE=${{ env.RELEASE_DATE }}
-            UNRELEASED_LINK=${{ github.event.release.html_url }}
-            UNRELEASED_VERSION=${{ github.event.release.tag_name }}
-      - name: Resolve npm channel
-        id: npm_channel
-        shell: bash
-        env:
-          GITHUB_PRERELEASE: ${{ github.event.release.prerelease }}
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if [[ "$VERSION" == *-* ]]; then
-            TAG=edge
-            EXPECTED_PRERELEASE=true
-          else
-            TAG=latest
-            EXPECTED_PRERELEASE=false
-          fi
-
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          if [[ "$GITHUB_PRERELEASE" != "$EXPECTED_PRERELEASE" ]]; then
-            echo "::warning title=Release metadata mismatch::Publishing $VERSION to '$TAG' based on its semver, ignoring GitHub prerelease=$GITHUB_PRERELEASE"
-          fi
-      - name: Upgrade npm for trusted publishing
-        run: npm install --global "npm@^11.5.1"
-      - name: Publish package with trusted publishing
-        env:
-          NPM_TAG: ${{ steps.npm_channel.outputs.tag }}
-        run: |
-          npm publish --access public --tag "$NPM_TAG" --dry-run
-          npm publish --access public --tag "$NPM_TAG"
-
-  finalize:
-    name: Finalize release
-    needs:
-      - release-npm
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Export formatted release date
-        shell: bash
-        env:
-          PUBLISHED_AT: ${{ github.event.release.published_at }}
-        run: echo "RELEASE_DATE=$(date -d "$PUBLISHED_AT" "+%B %e, %Y" | tr -s ' ')" >> "$GITHUB_ENV"
-      - name: Prepare and synchronize release
-        uses: tanaabased/prepare-release-action@v1
-        with:
           sync: true
           version: ${{ github.event.release.tag_name }}
           sync-token: ${{ secrets.RTFM47_COAXIUM_INJECTOR }}
@@ -113,3 +56,10 @@ jobs:
             UNRELEASED_DATE=${{ env.RELEASE_DATE }}
             UNRELEASED_LINK=${{ github.event.release.html_url }}
             UNRELEASED_VERSION=${{ github.event.release.tag_name }}
+      - name: Upgrade npm for trusted publishing
+        run: npm install --global "npm@^11.5.1"
+      - name: Publish package with trusted publishing
+        run: |
+          NPM_TAG=$(node -p "require('./package.json').version.includes('-') ? 'edge' : 'latest'")
+          npm publish --access public --tag "$NPM_TAG" --dry-run
+          npm publish --access public --tag "$NPM_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+### Developer Notes
+
+- Added pull-request dry runs for stable and prerelease npm publishing.
+- Fixed npm release channels to derive `latest` or `edge` from the stamped semver.
+- Removed the redundant npm release-promotion workflow.
+
 ## v1.0.0-beta.5 - [August 29, 2026](https://github.com/lando/leia/releases/tag/v1.0.0-beta.5)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ### Developer Notes
 
 - Added pull-request dry runs for stable and prerelease npm publishing.
-- Fixed npm release channels to derive `latest` or `edge` from the stamped semver.
-- Removed the redundant npm release-promotion workflow.
+- Fixed npm publishing to derive `latest` or `edge` from semver without a separate promotion workflow.
 
 ## v1.0.0-beta.5 - [August 29, 2026](https://github.com/lando/leia/releases/tag/v1.0.0-beta.5)
 

--- a/README.md
+++ b/README.md
@@ -247,11 +247,9 @@ Lando-based setup, validation, and pull request guidance.
 
 ## Releasing
 
-To deploy and publish a new version of the package to the `npm` registry you need only [create a release on GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) with a [semver](https://semver.org) tag.
+To deploy and publish a new version of the package to the `npm` registry, [create a release on GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) with a [semver](https://semver.org) tag. Stable versions publish to the `latest` npm tag and prerelease versions publish to `edge`; the version itself determines the channel even if the GitHub release metadata is incorrect.
 
-Note that prereleases will get pushed to the `edge` tag on the `npm` registry.
-
-The `@lando/leia` package must trust the `lando/leia` GitHub Actions publisher using `release.yml`. Publishing uses OIDC; `NPM_DEPLOY_TOKEN` is retained only for `npm dist-tag` promotion and should be a granular token scoped to this package.
+The `@lando/leia` package must trust the `lando/leia` GitHub Actions publisher using `release.yml`. Publishing uses OIDC without an npm token, and the version and changelog are synchronized back to the repository only after npm publishing succeeds.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Lando-based setup, validation, and pull request guidance.
 
 To deploy and publish a new version of the package to the `npm` registry, [create a release on GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) with a [semver](https://semver.org) tag. Stable versions publish to the `latest` npm tag and prerelease versions publish to `edge`; the version itself determines the channel even if the GitHub release metadata is incorrect.
 
-The `@lando/leia` package must trust the `lando/leia` GitHub Actions publisher using `release.yml`. Publishing uses OIDC without an npm token, and the version and changelog are synchronized back to the repository only after npm publishing succeeds.
+The `@lando/leia` package must trust the `lando/leia` GitHub Actions publisher using `release.yml`. Publishing uses OIDC without an npm token, while `prepare-release-action` synchronizes the version and changelog.
 
 ## Maintainers
 


### PR DESCRIPTION
## Summary

- remove the separate npm promotion path and trigger releases only on `release.published`
- derive `latest` versus `edge` from the stamped package semver instead of GitHub's prerelease checkbox
- let `prepare-release-action` synchronize the package version and changelog directly
- add concise pull-request dry runs for stable and prerelease package publication
- update the release documentation and unreleased changelog

## Failure investigated

The `v1.0.0-beta.5` GitHub release was not marked as a prerelease. The [publish run](https://github.com/lando/leia/actions/runs/33236682260) therefore called npm without a tag, and npm rejected the prerelease version. The separate [promotion run](https://github.com/lando/leia/actions/runs/33236682185) then attempted to promote a package that had never published and failed with HTTP 400.

This follows the concise npm release structure used by the Tanaab projects while removing Leia's unnecessary dist-tag promotion behavior.

## Validation

- parsed both workflow YAML files
- verified `git diff --check`
- verified both signed commits
- PR CI exercises stable (`latest`) and prerelease (`edge`) npm publish dry runs