### PR TITLE
ci: use release metadata for npm channel

### DIFF
--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -8,15 +8,17 @@ permissions:
 
 jobs:
   release-tests:
-    name: release-tests (${{ matrix.npm_tag }})
+    name: release-tests (${{ matrix.channel }})
     runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:
           - release_version: v9.9.9
-            npm_tag: latest
+            prerelease: false
+            channel: latest
           - release_version: v9.9.9-ci.${{ github.event.pull_request.head.sha }}
-            npm_tag: edge
+            prerelease: true
+            channel: edge
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -34,7 +36,11 @@ jobs:
           version: ${{ matrix.release_version }}
       - name: Validate npm publish
         env:
-          NPM_TAG: ${{ matrix.npm_tag }}
+          PRERELEASE: ${{ matrix.prerelease }}
         run: |
           npm install --global "npm@^11.5.1"
-          npm publish --access public --tag "$NPM_TAG" --dry-run
+          if [ "$PRERELEASE" == "false" ]; then
+            npm publish --access public --dry-run
+          else
+            npm publish --access public --tag edge --dry-run
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
         run: npm install --global "npm@^11.5.1"
       - name: Publish package with trusted publishing
         run: |
-          NPM_TAG=$(node -p "require('./package.json').version.includes('-') ? 'edge' : 'latest'")
-          npm publish --access public --tag "$NPM_TAG" --dry-run
-          npm publish --access public --tag "$NPM_TAG"
+          if [ "${{ github.event.release.prerelease }}" == "false" ]; then
+            npm publish --access public --dry-run
+            npm publish --access public
+          else
+            npm publish --access public --tag edge --dry-run
+            npm publish --access public --tag edge
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+- Fixed npm channel selection to follow GitHub release prerelease metadata.
+
 ## v1.0.0-beta.7 - [August 29, 2026](https://github.com/lando/leia/releases/tag/v1.0.0-beta.7)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Lando-based setup, validation, and pull request guidance.
 
 ## Releasing
 
-To deploy and publish a new version of the package to the `npm` registry, [create a release on GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) with a [semver](https://semver.org) tag. Stable versions publish to the `latest` npm tag and prerelease versions publish to `edge`; the version itself determines the channel even if the GitHub release metadata is incorrect.
+To deploy and publish a new version of the package to the `npm` registry, [create a release on GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) with a [semver](https://semver.org) tag. Stable GitHub releases publish to the `latest` npm tag, while releases marked as prereleases publish to `edge`.
 
 The `@lando/leia` package must trust the `lando/leia` GitHub Actions publisher using `release.yml`. Publishing uses OIDC without an npm token, while `prepare-release-action` synchronizes the version and changelog.
 


### PR DESCRIPTION
## Summary

- select the npm channel from `github.event.release.prerelease`
- publish stable GitHub releases to npm's default `latest` channel
- publish releases marked as prereleases to `edge`
- update PR dry runs to exercise a synthetic GitHub prerelease boolean
- align the README and unreleased changelog with the metadata-driven contract

## Rationale

This mirrors the release metadata branch in [`lando/core`](https://github.com/lando/core/blob/main/.github/workflows/deploy-npm.yml#L61-L79) and the current Tanaab npm release workflows. The GitHub Release's prerelease state is the operator-selected channel authority; the shape of `package.json.version` no longer decides the npm tag.

## Validation

- parsed both changed workflow YAML files
- verified stable metadata resolves to an untagged npm dry run
- verified prerelease metadata resolves to an `edge` npm dry run
- verified `git diff --check`
- verified the signed commit