### PR TITLE
ci: align npm tags with GitHub latest release

### DIFF
--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -8,17 +8,15 @@ permissions:
 
 jobs:
   release-tests:
-    name: release-tests (${{ matrix.channel }})
+    name: release-tests (${{ matrix.version_type }})
     runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:
           - release_version: v9.9.9
-            prerelease: false
-            channel: latest
+            version_type: stable-version
           - release_version: v9.9.9-ci.${{ github.event.pull_request.head.sha }}
-            prerelease: true
-            channel: edge
+            version_type: prerelease-version
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -34,13 +32,7 @@ jobs:
         with:
           sync: false
           version: ${{ matrix.release_version }}
-      - name: Validate npm publish
-        env:
-          PRERELEASE: ${{ matrix.prerelease }}
+      - name: Validate npm edge publish
         run: |
           npm install --global "npm@^11.5.1"
-          if [ "$PRERELEASE" == "false" ]; then
-            npm publish --access public --dry-run
-          else
-            npm publish --access public --tag edge --dry-run
-          fi
+          npm publish --access public --tag edge --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,6 @@ jobs:
         run: |
           LATEST_TAG=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')
 
-          if [ "$LATEST_TAG" = "${{ github.event.release.tag_name }}" ] && [ -z "$NPM_DIST_TAG_TOKEN" ]; then
-            echo "::error::NPM_DEPLOY_TOKEN is required to update the npm latest dist-tag."
-            exit 1
-          fi
-
           npm publish --access public --tag edge --dry-run
           npm publish --access public --tag edge
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,22 @@ jobs:
       - name: Upgrade npm for trusted publishing
         run: npm install --global "npm@^11.5.1"
       - name: Publish package with trusted publishing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NPM_DIST_TAG_TOKEN: ${{ secrets.NPM_DEPLOY_TOKEN }}
         run: |
-          if [ "${{ github.event.release.prerelease }}" == "false" ]; then
-            npm publish --access public --dry-run
-            npm publish --access public
-          else
-            npm publish --access public --tag edge --dry-run
-            npm publish --access public --tag edge
+          LATEST_TAG=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')
+
+          if [ "$LATEST_TAG" = "${{ github.event.release.tag_name }}" ] && [ -z "$NPM_DIST_TAG_TOKEN" ]; then
+            echo "::error::NPM_DEPLOY_TOKEN is required to update the npm latest dist-tag."
+            exit 1
+          fi
+
+          npm publish --access public --tag edge --dry-run
+          npm publish --access public --tag edge
+
+          if [ "$LATEST_TAG" = "${{ github.event.release.tag_name }}" ]; then
+            PACKAGE=$(node -p "require('./package.json').name")
+            VERSION=$(node -p "require('./package.json').version")
+            NODE_AUTH_TOKEN="$NPM_DIST_TAG_TOKEN" npm dist-tag add "$PACKAGE@$VERSION" latest
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,17 +58,14 @@ jobs:
       - name: Upgrade npm for trusted publishing
         run: npm install --global "npm@^11.5.1"
       - name: Publish package with trusted publishing
-        env:
-          GH_TOKEN: ${{ github.token }}
-          NPM_DIST_TAG_TOKEN: ${{ secrets.NPM_DEPLOY_TOKEN }}
         run: |
-          LATEST_TAG=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')
-
           npm publish --access public --tag edge --dry-run
           npm publish --access public --tag edge
-
-          if [ "$LATEST_TAG" = "${{ github.event.release.tag_name }}" ]; then
-            PACKAGE=$(node -p "require('./package.json').name")
-            VERSION=$(node -p "require('./package.json').version")
-            NODE_AUTH_TOKEN="$NPM_DIST_TAG_TOKEN" npm dist-tag add "$PACKAGE@$VERSION" latest
-          fi
+      - name: Promote package to latest
+        if: ${{ github.event.release.prerelease == false }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_DEPLOY_TOKEN }}
+        run: |
+          PACKAGE=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          npm dist-tag add "$PACKAGE@$VERSION" latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-- Fixed npm releases to publish every version to `edge` and promote only GitHub's latest release to `latest`.
+- Fixed npm releases to publish every version to `edge` and promote non-prerelease GitHub releases to `latest`.
 
 ## v1.0.0-beta.8 - [August 29, 2026](https://github.com/lando/leia/releases/tag/v1.0.0-beta.8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+- Fixed npm releases to publish every version to `edge` and promote only GitHub's latest release to `latest`.
+
 ## v1.0.0-beta.8 - [August 29, 2026](https://github.com/lando/leia/releases/tag/v1.0.0-beta.8)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Lando-based setup, validation, and pull request guidance.
 
 ## Releasing
 
-To deploy and publish a new version of the package to the `npm` registry, [create a release on GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) with a [semver](https://semver.org) tag. Every GitHub release publishes to the `edge` npm tag. When GitHub marks that release as the repository's latest release, the workflow also moves npm's `latest` tag to the same version; the prerelease checkbox does not choose the npm channel.
+To deploy and publish a new version of the package to the `npm` registry, [create a release on GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) with a [semver](https://semver.org) tag. Every GitHub release publishes to the `edge` npm tag. Releases not marked as prereleases also move npm's `latest` tag to the same version, regardless of the version string.
 
 The `@lando/leia` package must trust the `lando/leia` GitHub Actions publisher using `release.yml`. Package publication uses OIDC without an npm token. `NPM_DEPLOY_TOKEN` is a granular package token used only to update the `latest` dist-tag, while `prepare-release-action` synchronizes the version and changelog.
 

--- a/README.md
+++ b/README.md
@@ -247,9 +247,9 @@ Lando-based setup, validation, and pull request guidance.
 
 ## Releasing
 
-To deploy and publish a new version of the package to the `npm` registry, [create a release on GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) with a [semver](https://semver.org) tag. Stable GitHub releases publish to the `latest` npm tag, while releases marked as prereleases publish to `edge`.
+To deploy and publish a new version of the package to the `npm` registry, [create a release on GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) with a [semver](https://semver.org) tag. Every GitHub release publishes to the `edge` npm tag. When GitHub marks that release as the repository's latest release, the workflow also moves npm's `latest` tag to the same version; the prerelease checkbox does not choose the npm channel.
 
-The `@lando/leia` package must trust the `lando/leia` GitHub Actions publisher using `release.yml`. Publishing uses OIDC without an npm token, while `prepare-release-action` synchronizes the version and changelog.
+The `@lando/leia` package must trust the `lando/leia` GitHub Actions publisher using `release.yml`. Package publication uses OIDC without an npm token. `NPM_DEPLOY_TOKEN` is a granular package token used only to update the `latest` dist-tag, while `prepare-release-action` synchronizes the version and changelog.
 
 ## Maintainers
 


### PR DESCRIPTION
## What this changes

- publishes every GitHub Release to the npm `edge` dist-tag
- also moves npm `latest` to the published version when the Release is not marked as a prerelease
- determines promotion from `${{ github.event.release.prerelease }}`, not the version string
- dry-runs both stable-shaped and prerelease-shaped versions through the `edge` publication path on pull requests
- updates the release documentation and changelog

This lets a version such as `v1.0.0-beta.9` remain a normal GitHub Release and receive both npm tags, while a Release explicitly marked as a prerelease receives only `edge`.

Package publication continues to use npm trusted publishing through OIDC. The `NPM_DEPLOY_TOKEN` secret is isolated to the conditional `npm dist-tag add` step because trusted publishing does not authorize dist-tag mutation.

## Validation

- parsed both workflow files as YAML
- validated both release shell steps with `bash -n`
- ran `git diff --check`
- confirmed the workflow no longer makes a GitHub API call
- confirmed no release path publishes without the explicit `edge` tag
